### PR TITLE
Adding the missing guild field to Qcheck

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -448,7 +448,7 @@ async def imagine(interaction: nextcord.Interaction, prompt: str):
 
     await interaction.response.defer()  # Defer the response
 
-    check = qdb.qcheck(interaction.user.name, price)
+    check = qdb.qcheck(interaction.guild.id, interaction.user.name, price)
     if check != 0:
         await interaction.followup.send("Not enough QuackCoins", ephemeral=True)
         return


### PR DESCRIPTION
Close #28 

This pull request includes a modification to the `imagine` function in the `backend/src/main.py` file to include the guild ID when checking QuackCoins.

* [`backend/src/main.py`](diffhunk://#diff-1aa7be8fd177060491e662a7eb3bd936b827847c803cd95f08e3ff1c46160dcdL451-R451): Updated the `qcheck` function call to include `interaction.guild.id` as an additional parameter for more accurate user verification.