### PR TITLE
Fixing the typo and the location of the backup file

### DIFF
--- a/backend/src/qdatabase.py
+++ b/backend/src/qdatabase.py
@@ -240,7 +240,7 @@ def send(guild, fname, dname, amount):
     data = CURSOR.fetchall()
     fcoin = data[0][0]
     if fcoin < amount:
-        return("INSUFICIENT FUNDS")
+        return("INSUFFICIENT FUNDS")
     
     CURSOR.execute(f"UPDATE '{guild}' SET coins = ? WHERE name = ?", (fcoin-amount, fname))
     CONNECTION.commit()
@@ -429,7 +429,7 @@ def clear_stats(guild):
 
 def backup_db():
     bckup_path = os.path.join(ROOT_DIR, "db/backup/")
-    bckup_file = os.path.join(ROOT_DIR, "bckup_quackers.db")
+    bckup_file = os.path.join(backup_db, "bckup_quackers.db")
 
     os.makedirs(bckup_path, exist_ok=True)
 


### PR DESCRIPTION
Close #30 
Close #27 

This pull request includes minor corrections and improvements in the `backend/src/qdatabase.py` file. 

* Fixed a typo in the error message returned when there are insufficient funds.
* Corrected the path variable used in the `backup_db` function to ensure the backup file is correctly saved.