### PR TITLE
Correcting the misspelling of the name of the dice file

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -758,7 +758,7 @@ async def roll(
     # File path fix
     filepath_dice = None
     if sides == 20 and dice_num == 1:
-        filepath_dice = os.path.join(DATA_DIR, f'imgs/dices/roll.{random.randint(0,4)}.{sumroll-1}.webp')
+        filepath_dice = os.path.join(DATA_DIR, f'imgs/dices/ROLL.{random.randint(0,4)}.{sumroll-1}.webp')
 
     # Message formatting
     message = f"🎲 **{interaction.user.name.capitalize()}** rolled a d{sides} dice {dice_num} times."


### PR DESCRIPTION
This pull request includes a minor change to the `roll` function in `backend/src/main.py`. The change updates the file path formatting to use uppercase "ROLL" instead of lowercase "roll" in the constructed file path.

* [`backend/src/main.py`](diffhunk://#diff-1aa7be8fd177060491e662a7eb3bd936b827847c803cd95f08e3ff1c46160dcdL761-R761): Changed the file path string from `roll` to `ROLL` in the `filepath_dice` assignment to ensure consistency or meet a specific requirement.

Close #66