### PR TITLE
Format leaderboard numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A discord bot in Python with a lot of functionalities.
   - `/bank` : Allows the user to store coins to get interest
   - `/send` : Send coins from a User to another
   - `/daily` : Receive Daily Coins everyday (with a Streak function, the more you do it, the more you get)
-  - `/leaderboard` : Display the Top 10 Users with the most coins
+  - `/leaderboard` : Display the Top 10 Users with the most coins (values use dots as thousand separators)
 - 🎲 || **Games** <sub>[Play Games and earn Coins]</sub>
   - `/dices` : Throw dices against Quackers, the one with the most points wins
   - `/rps` : Play Rock Paper Scissors Lizard Spoke with Quackers

--- a/backend/src/qdatabase.py
+++ b/backend/src/qdatabase.py
@@ -375,7 +375,9 @@ def leaderboard(guild):
         bold = ""
         if i <= 2:
             bold = "**"
-        result.append(f'{emoji[emo]} N.{i+1} :: {bold}{data[i][0].capitalize()}{bold} :: {(data[i][1] + data[i][2])} <:quackCoin:1124255606782578698>')
+        total = data[i][1] + data[i][2]
+        formatted_total = f"{total:,}".replace(",", ".")
+        result.append(f'{emoji[emo]} N.{i+1} :: {bold}{data[i][0].capitalize()}{bold} :: {formatted_total} <:quackCoin:1124255606782578698>')
     return(result)
 
 def voiceactive(guild, name):


### PR DESCRIPTION
## Summary
- display leaderboard totals with dots as thousand separators
- document new output format in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bd06bcd6083269eb91fbd5624b90c