### PR TITLE
Add database sync flag and auto command refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,12 @@ A discord bot in Python with a lot of functionalities.
 - **Real-Time Server Data**  
   Auto-fetch guild info (channels, roles, etc.) from the Discord API for config.
 
-- **Live Config Saving**  
+- **Live Config Saving**
   All changes are stored to the database via a `/save-config` endpoint.
+
+- **Config Sync Delay**
+  After saving, it can take **5-10 minutes** for new settings and commands to
+  appear on Discord while the bot refreshes.
 
 - **Smart UI**  
   Dynamic input toggles, JS-powered visibility, and field disabling for smooth admin experience.

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1007,6 +1007,28 @@ async def before_weekly_update():
     qlogs.info(f"Waiting for {wait_time} seconds until the next Sunday...")
     await asyncio.sleep(wait_time)
 
+# Sync commands for servers marked for update
+@tasks.loop(minutes=5)
+async def sync_commands_update():
+    servers = qdb.get_nsync_servers()
+    for sid in servers:
+        guild = bot.get_guild(sid)
+        if guild:
+            try:
+                await bot.sync_application_commands(guild)
+                qdb.set_nsync(sid, 0)
+                qlogs.info(f"Synced commands for {sid}")
+
+                channel = bot.get_channel(qdb.get_server_info(sid, "dbg_ch_id"))
+                if channel and qdb.get_server_info(sid, "dbg_ch") == True:
+                    await channel.send("Commands have been refreshed")
+            except Exception as e:
+                qlogs.error(f"Failed to sync commands for {sid}: {e}")
+
+@sync_commands_update.before_loop
+async def before_sync_commands_update():
+    await bot.wait_until_ready()
+
 # EVENTS
 #QUACKER IS READY 
 @bot.event
@@ -1017,6 +1039,8 @@ async def on_ready():
         daily_update.start()
     if not weekly_update.is_running():
         weekly_update.start()
+    if not sync_commands_update.is_running():
+        sync_commands_update.start()
 
     for guild in bot.guilds:
         qdb.add_server(guild.id, guild.name)

--- a/backend/src/qdatabase.py
+++ b/backend/src/qdatabase.py
@@ -93,7 +93,8 @@ DB_STRUCTURE_SERVER = '''
 "ai_chat" BOOLEAN DEFAULT 0,
 "ai_img" BOOLEAN DEFAULT 0,
 "ai_img_pay" BOOLEAN DEFAULT 1,
-"ai_img_pay_value" INTEGER DEFAULT 100
+"ai_img_pay_value" INTEGER DEFAULT 100,
+"nsync" BOOLEAN DEFAULT 0
 '''
 
 DB_STRUCTURE_MEMBERS = '''
@@ -160,6 +161,15 @@ def get_server_name(guild):
     CURSOR.execute('SELECT server_name FROM servers WHERE server_id = ?', (guild,))
     result = CURSOR.fetchone()
     return result
+
+def set_nsync(guild, value=1):
+    CURSOR.execute('UPDATE servers SET nsync = ? WHERE server_id = ?', (value, guild))
+    CONNECTION.commit()
+
+def get_nsync_servers():
+    CURSOR.execute('SELECT server_id FROM servers WHERE nsync = 1')
+    rows = CURSOR.fetchall()
+    return [row[0] for row in rows]
 
 #MEMBERS
 def user_in_db(guild, member):

--- a/web/database.py
+++ b/web/database.py
@@ -1,6 +1,7 @@
 from .consts import ROOT_DIR, TXT_DIR
 import sqlite3
 import os
+import qlogs
 
 def server_check(server, name):
     #check that the db file exists
@@ -43,8 +44,10 @@ def update_server_info(guild, parm, value):
     conn = sqlite3.connect(f"{ROOT_DIR}/db/quackers.db")
     cursor = conn.cursor()
 
-    cursor.execute(f"UPDATE servers SET {parm} = ? WHERE server_id = ?", (value, guild))
+    cursor.execute(f"UPDATE servers SET {parm} = ?, nsync = 1 WHERE server_id = ?", (value, guild))
     conn.commit()
+
+    qlogs.info(f"Server {guild} updated {parm} -> {value} (nsync set)")
 
     conn.close()
 


### PR DESCRIPTION
## Summary
- extend `servers` table with a `nsync` column
- mark a server for sync whenever settings are saved via the web API
- expose helpers `set_nsync` and `get_nsync_servers`
- add background task to refresh slash commands when needed
- log when commands refresh and note delay in README

## Testing
- `python -m py_compile backend/src/qdatabase.py web/database.py backend/src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_685b31a3bff08326b9a2792eaa31bff8