### PR TITLE
Fix weekly stats and quacker add

### DIFF
--- a/backend/src/qdatabase.py
+++ b/backend/src/qdatabase.py
@@ -238,7 +238,7 @@ def add_quackers(guild, name):
 
     quackers += 1
 
-    CURSOR.execute(f"UPDATE '{guild}' quackers = ? WHERE name = ?", (quackers, name))
+    CURSOR.execute(f"UPDATE '{guild}' SET quackers = ? WHERE name = ?", (quackers, name))
     CONNECTION.commit()
 
 def daily(guild, name):


### PR DESCRIPTION
## Summary
- update image regeneration to charge using server setting
- show prompt details using ephemeral response
- avoid stats crash if there are no departures
- fix SQL syntax when incrementing quackers count

## Testing
- `python -m py_compile backend/src/main.py`
- `python -m py_compile backend/src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6864e61f9ed08326bef620dab3e6f523