### PR TITLE
Add weekly stats hour breakdown

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -922,12 +922,21 @@ async def before_daily_update():
 async def weekly_update():
     qlogs.info("WEEKLY UPDATE")
 
-    for server in serverid:
+    for server in qdb.get_server_list("stats"):
 
-        type_totals, type_min_max, unique_names_count, interval_totals, type_most_entries = qdb.get_stats(server)
+        (
+            type_totals,
+            type_min_max,
+            unique_names_count,
+            interval_totals,
+            hour_totals,
+            type_most_entries,
+        ) = qdb.get_stats(server)
 
         path = qdraw.stat(interval_totals)
         imgfile = nextcord.File(path)
+
+        advanced = qdb.get_server_info(server, "stats_advanced")
 
         message = ["**📊 Server Activity Statistics**"]
 
@@ -950,12 +959,22 @@ async def weekly_update():
                 game = dict(type_totals)['GAME']
             except:
                 game = 0
-            message.append(f"\n**Commands Quantity This Week:** `{cmd + game}`")
+        message.append(f"\n**Commands Quantity This Week:** `{cmd + game}`")
 
         # Add type totals
         message.append("\n\n**Activity Summary:**")
         for activity, count in type_totals:
             message.append(f"- **{activity}:** `{count}` entries")
+
+        days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+        busiest_day_index = interval_totals.index(max(interval_totals))
+        busiest_hour = hour_totals.index(max(hour_totals))
+        message.append(
+            f"\n**Busiest Day:** `{days[busiest_day_index]}` with `{interval_totals[busiest_day_index]}` activities"
+        )
+        message.append(
+            f"\n**Peak Hour:** `{busiest_hour}:00` with `{max(hour_totals)}` activities"
+        )
 
         # Add detailed stats for each type
         message.append("\n\n**Detailed Statistics by Type:**")
@@ -986,11 +1005,14 @@ async def weekly_update():
 
         # Combine all parts into a single string
         mess = "\n".join(message)
-        mess = mess[:1000] #Cutting too long message
+        mess = mess[:1000]  # Cutting too long message
 
-        channel = bot.get_channel(qdb.get_server_info(server, "admin_ch_id"))
+        channel = bot.get_channel(qdb.get_server_info(server, "stats_ch_id"))
         if channel:
-            await channel.send(mess, file=imgfile)
+            if advanced:
+                await channel.send(mess, file=imgfile)
+            else:
+                await channel.send(message[0], file=imgfile)
             
         qdb.clear_stats(guild=server) #CLEAR STATS
 
@@ -1084,7 +1106,7 @@ def vc_disconnect(guild, member):
     hours = qdb.voicestalled(guild.id, member.name)
     qlogs.info(f"{member.name} is disconnected")
 
-    qdb.add_stat(guild=guild.id, user=member.name, type="VC_HOUR", amount=hours)
+    qdb.add_stat(guild=guild.id, user=member.name, type="VC_HOURS", amount=hours)
 
 @bot.event
 async def on_voice_state_update(member, before, after):

--- a/web/static/js/config-general.js
+++ b/web/static/js/config-general.js
@@ -17,6 +17,19 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!toggle.checked) {
         inputField.disabled = true;
     }
+
+    const statsToggle = document.getElementById('stats-toggle');
+    const statsInput = document.getElementById('stats-input');
+    statsToggle.addEventListener('change', () => {
+        if (statsToggle.checked) {
+            statsInput.disabled = false;
+        } else {
+            statsInput.disabled = true;
+        }
+    });
+    if (!statsToggle.checked) {
+        statsInput.disabled = true;
+    }
 });
 
 //BUTTON SAVE
@@ -28,6 +41,9 @@ document.getElementById("btn-general-main").addEventListener("click", () => {
         { name: "dbg_ch_id", value: document.getElementById("debug-input").value },
         { name: "bot_ch_id", value: document.getElementById("bot-txt-channel").value },
         { name: "admin_ch_id", value: document.getElementById("admin-txt-channel").value },
+        { name: "stats", value: document.getElementById("stats-toggle").checked ? 1 : 0 },
+        { name: "stats_advanced", value: document.getElementById("stats-advanced-toggle").checked ? 1 : 0 },
+        { name: "stats_ch_id", value: document.getElementById("stats-input").value },
     ];
     saveConfig(
         "btn-general-main",

--- a/web/static/js/config-general.js
+++ b/web/static/js/config-general.js
@@ -20,16 +20,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const statsToggle = document.getElementById('stats-toggle');
     const statsInput = document.getElementById('stats-input');
-    statsToggle.addEventListener('change', () => {
+    const advancedToggle = document.getElementById('stats-advanced-toggle');
+
+    const toggleStatsFields = () => {
         if (statsToggle.checked) {
             statsInput.disabled = false;
+            advancedToggle.disabled = false;
         } else {
             statsInput.disabled = true;
+            advancedToggle.disabled = true;
         }
-    });
-    if (!statsToggle.checked) {
-        statsInput.disabled = true;
-    }
+    };
+
+    statsToggle.addEventListener('change', toggleStatsFields);
+    toggleStatsFields();
 });
 
 //BUTTON SAVE

--- a/web/templates/config-general.html
+++ b/web/templates/config-general.html
@@ -55,7 +55,25 @@
                                 <option {% if data["admin_ch_id"]|int == channel.id|int %} selected="selected" {% endif %} value="{{ channel.id }}">{{ channel.name }}</option>
                             {% endfor %}
                         </select>
-                    </div>                                  
+                    </div>
+                    <div class="mb-3" style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap;">
+                        <label for="stats-txt-channel" class="form-label">Statistics channel text</label>
+                        <div class="form-check form-switch">
+                            <input class="form-check-input toggle-section" type="checkbox" id="stats-toggle"  {% if data['stats'] == 1 %} checked {% endif %}>
+                            <label class="form-check-label" for="stats-toggle">Active</label>
+                        </div>
+                        <select id="stats-input" class="form-select">
+                            {% for channel in server["text_channels"] %}
+                                <option {% if data["stats_ch_id"]|int == channel.id|int %} selected="selected" {% endif %} value="{{ channel.id }}">{{ channel.name }}</option>
+                            {% endfor %}
+                        </select>
+
+                        <div class="form-check form-switch" style="margin-top: 0.5rem;">
+                            <input class="form-check-input" type="checkbox" id="stats-advanced-toggle" {% if data['stats_advanced'] == 1 %} checked {% endif %}>
+                            <label class="form-check-label" for="stats-advanced-toggle">Advanced</label>
+                        </div>
+
+                    </div>
                 </form>
             </div>
             <button id="btn-general-main" type="button" class="btn button text-white">Save Changes</button>


### PR DESCRIPTION
## Summary
- track hour of day in stats data
- include hour totals in weekly stats reports
- add busiest day and peak hour to weekly message
- rename `VC_HOUR` stat type to `VC_HOURS`
- rename server flag to `stats` and add `stats_advanced` option
- limit weekly message if advanced stats disabled

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6863d218a2e48326b7b16118f0b89b5c